### PR TITLE
Fix xyspacing in invesalius/control.py

### DIFF
--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -712,7 +712,7 @@ class Controller():
            else:
                return
 
-           xyspacing = xyspacing[0] / resolution_percentage, xyspacing[1] / resolution_percentage
+       xyspacing = xyspacing[0] / resolution_percentage, xyspacing[1] / resolution_percentage
  
 
        
@@ -811,7 +811,7 @@ class Controller():
                 else:
                     return
 
-                xyspacing = xyspacing[0] / resolution_percentage, xyspacing[1] / resolution_percentage
+            xyspacing = xyspacing[0] / resolution_percentage, xyspacing[1] / resolution_percentage
 
             self.matrix, scalar_range, self.filename = image_utils.dcm2memmap(filelist, size,
                                                                         orientation, resolution_percentage)


### PR DESCRIPTION
Running Invesalius via CLI to export DICOM/Bitmap to 3D (STL, OBJ et all) generated stretched 3Ds while in GUI everything was fine. The bug was present in _OpenBitmapFiles()_ and _OpenDicomGroup()_, I'll refer to the latter method: after calculating _resolution_percentage_ (**line 800**) when in GUI _xyspacing_ was adjusted accordingly (**line 814**) but, since via CLI the if condition (**line 802**) it's not met, this caused discrepancies in the 3D dimensions. 

This subtle bug was probably caused due to an error in indentation, moving **line 814** outside of **line 802** if, fixed the issue in my scenarios and should be sufficient.